### PR TITLE
fix: strip markdown from session names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "cordova-plugin-inappbrowser": "5.0.0",
         "cordova-plugin-ionic": "5.5.3",
         "core-js": "^3.6.4",
+        "markdown-to-txt": "^2.0.1",
         "rxjs": "^6.5.4",
         "sha1-uint8array": "^0.10.5",
         "sw-toolbox": "3.6.0",
@@ -13350,6 +13351,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -13384,6 +13390,11 @@
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
+    },
+    "node_modules/lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -13747,6 +13758,27 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/markdown-to-txt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-txt/-/markdown-to-txt-2.0.1.tgz",
+      "integrity": "sha512-Hsj7KTN8k1gutlLum3vosHwVZGnv8/cbYKWVkUyo/D1rzOYddbDesILebRfOsaVfjIBJank/AVOySBlHAYqfZw==",
+      "dependencies": {
+        "lodash.escape": "^4.0.1",
+        "lodash.unescape": "^4.0.1",
+        "marked": "^4.0.14"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -30390,6 +30422,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -30424,6 +30461,11 @@
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg=="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -30703,6 +30745,21 @@
           "dev": true
         }
       }
+    },
+    "markdown-to-txt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-txt/-/markdown-to-txt-2.0.1.tgz",
+      "integrity": "sha512-Hsj7KTN8k1gutlLum3vosHwVZGnv8/cbYKWVkUyo/D1rzOYddbDesILebRfOsaVfjIBJank/AVOySBlHAYqfZw==",
+      "requires": {
+        "lodash.escape": "^4.0.1",
+        "lodash.unescape": "^4.0.1",
+        "marked": "^4.0.14"
+      }
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cordova-plugin-inappbrowser": "5.0.0",
     "cordova-plugin-ionic": "5.5.3",
     "core-js": "^3.6.4",
+    "markdown-to-txt": "^2.0.1",
     "rxjs": "^6.5.4",
     "sha1-uint8array": "^0.10.5",
     "sw-toolbox": "3.6.0",

--- a/src/app/providers/conference-data.ts
+++ b/src/app/providers/conference-data.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 import { map, timeout, catchError } from 'rxjs/operators';
 import { Storage } from '@ionic/storage';
 import { ToastController } from '@ionic/angular';
+import markdownToTxt from 'markdown-to-txt';
 
 import { UserData } from './user-data';
 
@@ -89,6 +90,9 @@ export class ConferenceData {
           }
         });
       }
+
+      // transform any markdown slot names to regular text
+      slot.name = markdownToTxt(slot.name);
 
       var start = new Date(slot.start);
       var end = new Date(slot.end);


### PR DESCRIPTION
Two roads diverged in a yellow wood,
And sorry I could not travel both
And be one traveler, long I stood
And looked down one as far as I could
To where it bent in the undergrowth;

I initially tried to use `ngx-markdown` to be able to use the markdown and render it inline, but due to the undergrowth of using older ionic and angular dependencies (from the template project), there's enough conflicts that I decided this was infinitely simpler for now.

Fixes #12